### PR TITLE
added token lifetime handling for both jwt and non-jwt tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-Angular token authentication are services for handling token-based authentication as a client-side session with automatic (optional) handling of REST resources in angular apps. It is divided in two modules.
+Angular token authentication are services for handling token-based authentication as a client-side session with automatic (optional) handling of REST resources in angular apps. It supports the usage of [jwt](https://jwt.io) tokens. It is divided in two modules.
 
- 
+
 ![codeship](https://codeship.com/projects/5e91d1a0-7a84-0132-7c8e-5ed8b09d11ae/status?branch=master)
 
 
 # Parameters
 
-- `sessionDuration`: duration of the session (in minutes). A falsy value (`0`, `false`) means the session will not expire. Default: `30`
-- `idleTime`: duration of the session while idle (in minutes). A falsy value (`0`, `false`) means the session will not expire by idle time. Default: `20`
+- `sessionDuration`: duration of the session (in minutes). A falsy value (`0`, `false`) means the session will not be forced to expire (it will expire when/if token expires instead). Default: `0`
+- `idleTime`: duration of the session while idle (in minutes). A falsy value (`0`, `false`) means the session will not expire by idle time. Default: `0`
 - `accessTokenKey`: access token key for calls to the API (necessary for resource authentication in tokenAuthResource). Default: `'accessToken'`
+- `jwt`: if tokens should be treated as [jwt](https://jwt.io) tokens for the purposes of expiration handling.
 
 # API
 
@@ -89,6 +90,12 @@ bower install angular-token-authentication --save
 ```
 
 Include the files, load the modules on the app and set parameters:
+
+```html
+<!--if using jwt-->
+<script src="bower_components/angular-jwt/dist/angular-jwt.min.js"></script>
+<script src="bower_components/angular-token-authentication/angular-token-authentication.js"></script>
+```
 
 ```javascript
 angular.module("AppModule", ["tokenAuthResource"]) //should be enough to load both modules (it depends on tokenAuthentication)

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
   "homepage": "https://github.com/Yeti-Media/angular-token-authentication.git",
   "main": "angular-token-authentication.js",
   "dependencies": {
+    "angular-jwt": "~0.0.9",
     "angular-resource": "~1.2.9"
   },
   "devDependencies": {

--- a/example/app.js
+++ b/example/app.js
@@ -2,7 +2,7 @@ var app = angular.module("App", ["tokenAuthResource", "ngMockE2E"]);
 
 /* Backend mock */
 app.run(function($httpBackend) {
-  $httpBackend.whenPOST("/login").respond(200, {accessToken: "a1"});
+  $httpBackend.whenPOST("/login").respond(200, {access_token: "a1", expires_in: "60"});
   $httpBackend.whenGET("/privatePosts").respond(401, {error: "You are not authorized to view the posts."});
   $httpBackend.whenGET("/privatePosts?accessToken=a1").respond(200, [{body: "This is a private post."}, {body: "This is another."}, {body: "etc."}]);
 });
@@ -29,7 +29,7 @@ app.controller("MainCtrl", function($scope, $http, privatePosts, sessionHandler)
       method: "POST",
       url: "/login"
     }).success(function(data) {
-      sessionHandler.setAccessToken(data.accessToken);
+      sessionHandler.setAccessToken(data);
       queryPosts();
     });
   }

--- a/example/index.html
+++ b/example/index.html
@@ -1,9 +1,9 @@
 <html>
   <head>
     <script src="../bower_components/angular/angular.js"></script>
-    <script src="../bower_components/angular-cookies/angular-cookies.js"></script>
     <script src="../bower_components/angular-mocks/angular-mocks.js"></script>
     <script src="../bower_components/angular-resource/angular-resource.js"></script>
+    <script src="../bower_components/angular-jwt/dist/angular-jwt.min.js"></script>
     <script src="../angular-token-authentication.js"></script>
     <script src="app.js"></script>
   </head>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,6 +18,7 @@ module.exports = function(config) {
       'bower_components/angular-resource/angular-resource.js',
       'bower_components/angular-mocks/angular-mocks.js',
       'bower_components/angular-cookies/angular-cookies.js',
+      'bower_components/angular-jwt/dist/angular-jwt.js',
       'lib/tokenAuthentication.js',
       'lib/sessionHandler.js',
       'lib/tokenAuthResource.js',
@@ -27,7 +28,7 @@ module.exports = function(config) {
 
     // list of files to exclude
     exclude: [
-      
+
     ],
 
 

--- a/lib/sessionHandler.js
+++ b/lib/sessionHandler.js
@@ -1,5 +1,5 @@
-tokenAuthentication.factory("sessionHandler", 
-  ["$rootScope", "$window", "tokenAuthParams", function($scope, $window, tokenAuthParams) {
+angular.module("tokenAuthentication").factory("sessionHandler",
+  ["$rootScope", "$window", "tokenAuthParams", "jwtHelper", function($scope, $window, tokenAuthParams, jwtHelper) {
     var accessTokenKey = "accessToken",
     storage = $window.sessionStorage,
     getKey = function(key) {
@@ -17,13 +17,16 @@ tokenAuthentication.factory("sessionHandler",
       },
 
       setValue: function(key, value, remember) {
-        if (this.empty()) {
+        if (key === accessTokenKey) {
+          this.setExpiration(value);
+          this.setIdleTimer();
+          $scope.$broadcast("tokenAuth:loggedIn");
+          value = value.access_token;
+        } else if (this.empty()) {
           this.setExpiration();
           this.setIdleTimer();
         }
         setValue(key, value, remember);
-        if (key === accessTokenKey)
-          $scope.$broadcast("tokenAuth:loggedIn");
       },
 
       setValues: function(data) {
@@ -51,13 +54,32 @@ tokenAuthentication.factory("sessionHandler",
         return this.getValue(accessTokenKey);
       },
 
-      setExpiration: function() {
-        var date = new Date(),
-        duration = tokenAuthParams.sessionDuration;
-        if (!duration) return;
+      setExpiration: function(token) {
+        var duration = tokenAuthParams.sessionDuration,
+        expiresAt,
+        clientExpiration;
 
-        date.setMinutes(date.getMinutes() + duration);
-        storage.tokenAuth_expiration = date.getTime().toString();
+        if (token) {
+          if (tokenAuthParams.jwt) {
+            expiresAt = jwtHelper.getTokenExpirationDate(token);
+          } else if (token.expires_in) {
+            expiresAt = new Date();
+            // 60 seconds less to secure browser and response latency
+            expiresAt.setSeconds(expiresAt.getSeconds() + parseInt(token.expires_in) - 60);
+          }
+        }
+
+        if (duration) {
+          clientExpiration = new Date();
+          clientExpiration.setMinutes(clientExpiration.getMinutes() + duration);
+          if (!expiresAt || clientExpiration.getTime() < expiresAt.getTime()) {
+            expiresAt = clientExpiration;
+          }
+        }
+
+        if (expiresAt) {
+          storage.tokenAuth_expiration = expiresAt.getTime().toString();
+        }
       },
 
       checkExpiration: function() {
@@ -104,7 +126,7 @@ tokenAuthentication.factory("sessionHandler",
         angular.forEach(values, function(data, key) {
           if (force || !data.remember) {
             delete values[key];
-            if (key === accessTokenKey) 
+            if (key === accessTokenKey)
               $scope.$broadcast("tokenAuth:loggedOut");
           }
         });

--- a/lib/tokenAuthResource.js
+++ b/lib/tokenAuthResource.js
@@ -1,4 +1,4 @@
-angular.module("tokenAuthResource", ["ngResource", "tokenAuthentication"]).factory("tokenAuthResource", 
+angular.module("tokenAuthResource", ["ngResource", "tokenAuthentication"]).factory("tokenAuthResource",
   ["$resource", "sessionHandler", "tokenAuthParams", function($resource, sessionHandler, tokenAuthParams) {
     return function() {
       var resource = $resource.apply(this, arguments),
@@ -24,9 +24,9 @@ angular.module("tokenAuthResource", ["ngResource", "tokenAuthentication"]).facto
               args.unshift({});
 
             args[0][tokenAuthParams.accessTokenKey] = sessionHandler.getAccessToken();
-          }
 
-          original.apply(this, args);
+            original.apply(this, args);
+          }
         };
       });
 

--- a/lib/tokenAuthentication.js
+++ b/lib/tokenAuthentication.js
@@ -1,7 +1,8 @@
-var tokenAuthentication = angular.module("tokenAuthentication", ["ngCookies"]);
+var tokenAuthentication = angular.module("tokenAuthentication", ["angular-jwt"]);
 
 tokenAuthentication.value("tokenAuthParams", {
-  sessionDuration: 30, // in minutes
-  idleTime: 20, //in minutes
-  accessTokenKey: "accessToken"
+  sessionDuration: 0, // in minutes
+  idleTime: 0, //in minutes
+  accessTokenKey: "accessToken",
+  jwt: false
 });


### PR DESCRIPTION
it will now handle token lifetime (if present) whether it comes with the oauth standard 'expires_in' property, or encoded in a jwt token.

It will now avoid making requests with an expired token; an automatic token renewal feature via refresh tokens is in the works.
